### PR TITLE
修复了sl变牌的big（增加了一个patch）

### DIFF
--- a/src/main/java/hannina/cards/HanninaDefence.java
+++ b/src/main/java/hannina/cards/HanninaDefence.java
@@ -4,9 +4,12 @@ import basemod.abstracts.CustomSavable;
 import com.megacrit.cardcrawl.actions.common.GainBlockAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import com.megacrit.cardcrawl.random.Random;
 import hannina.fantasyCard.AbstractHanninaCard;
 import hannina.misc.SaveData;
+import hannina.utils.ModHelper;
 
 public class HanninaDefence extends AbstractHanninaCard implements CustomSavable<Integer> {
 

--- a/src/main/java/hannina/misc/SaveData.java
+++ b/src/main/java/hannina/misc/SaveData.java
@@ -1,6 +1,7 @@
 package hannina.misc;
 
 import hannina.cards.Zuiainile;
+import hannina.patches.utils.CardSeedBeforeRollPatch;
 import hannina.utils.ModHelper;
 
 public class SaveData {
@@ -18,6 +19,11 @@ public class SaveData {
     public static SaveData save() {
         if (saveData == null)
             saveData = new SaveData();
+
+        if(CardSeedBeforeRollPatch.hue_count_before_roll != -1) {
+            saveData.hueRngCounter = CardSeedBeforeRollPatch.hue_count_before_roll;
+            CardSeedBeforeRollPatch.hue_count_before_roll = -1;
+        }
 
         return saveData;
     }

--- a/src/main/java/hannina/patches/utils/CardSeedBeforeRollPatch.java
+++ b/src/main/java/hannina/patches/utils/CardSeedBeforeRollPatch.java
@@ -1,0 +1,20 @@
+package hannina.patches.utils;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpireInsertPatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpireReturn;
+import com.megacrit.cardcrawl.rooms.AbstractRoom;
+import hannina.utils.UnionManager;
+
+public class CardSeedBeforeRollPatch {
+    public static int hue_count_before_roll = 0;
+
+    @SpirePatch(clz = AbstractRoom.class, method = "update")
+    public static class AbstractRoomPatch {
+        @SpireInsertPatch(rloc = 428-252)
+        public static SpireReturn Insert(AbstractRoom _inst) {
+            hue_count_before_roll = UnionManager.rng.counter;
+            return SpireReturn.Continue();
+        }
+    }
+}

--- a/src/main/java/hannina/utils/UnionManager.java
+++ b/src/main/java/hannina/utils/UnionManager.java
@@ -79,8 +79,6 @@ public class UnionManager {
             SaveData.saveData = new SaveData();
         }
         rng = new Random(Settings.seed, SaveData.saveData.hueRngCounter);
-        ModHelper.logger.info("==========Seeds loaded: {} ==========", rng.copy().random(1000));
-        int a = 1;
     }
 
     public static void configureOnSpawn(AbstractCard c) {

--- a/src/main/java/hannina/utils/UnionManager.java
+++ b/src/main/java/hannina/utils/UnionManager.java
@@ -8,6 +8,7 @@ import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.helpers.CardLibrary;
 import com.megacrit.cardcrawl.random.Random;
 import com.megacrit.cardcrawl.rooms.AbstractRoom;
+import com.megacrit.cardcrawl.screens.CardRewardScreen;
 import hannina.fantasyCard.AbstractHanninaCard;
 import hannina.misc.ReunionModifier;
 import hannina.misc.SaveData;
@@ -24,20 +25,24 @@ public class UnionManager {
     public static int getRamdom(int index) {
         if (index < 0) return 0;
 
-        Random rng;
+        Random rng = null;
         boolean flag = false;
 
         if (AbstractDungeon.player != null &&
                 AbstractDungeon.currMapNode != null &&
-                AbstractDungeon.currMapNode.room != null &&
-                AbstractDungeon.currMapNode.room.monsters != null) {
-            if ((AbstractDungeon.getCurrRoom()).phase == AbstractRoom.RoomPhase.COMBAT && !(AbstractDungeon.getCurrRoom()).isBattleOver) {
+                AbstractDungeon.currMapNode.room != null) {
+            if ((AbstractDungeon.getCurrRoom()).phase == AbstractRoom.RoomPhase.COMBAT) {
                 rng = AbstractDungeon.cardRandomRng;
-            } else {
+            }
+//            else if ((AbstractDungeon.getCurrRoom()).phase == AbstractRoom.RoomPhase.COMPLETE) {
+//                rng = UnionManager.rng;
+//            }
+            else {
                 rng = UnionManager.rng;
                 flag = true;
             }
-        } else
+        }
+        if (rng == null)
             rng = new Random();
 
         int n = rng.random(index - 1);
@@ -74,6 +79,8 @@ public class UnionManager {
             SaveData.saveData = new SaveData();
         }
         rng = new Random(Settings.seed, SaveData.saveData.hueRngCounter);
+        ModHelper.logger.info("==========Seeds loaded: {} ==========", rng.copy().random(1000));
+        int a = 1;
     }
 
     public static void configureOnSpawn(AbstractCard c) {
@@ -98,7 +105,7 @@ public class UnionManager {
 
             //切回本体有时候也要切回无色牌
             AbstractCard tmp = mod.union.stream().filter(u -> u.color == color).findFirst().orElse(null);
-            if(tmp == null && color == Enums.HanninaColor)
+            if (tmp == null && color == Enums.HanninaColor)
                 tmp = mod.union.stream().filter(u -> u.color == AbstractCard.CardColor.COLORLESS).findFirst().orElse(null);
 
 


### PR DESCRIPTION
视野生成战斗中是先升成卡牌再保存，sl后是先读取再生成卡牌，导致随机数序列全乱了，依托答辩这个代码。